### PR TITLE
Display bundled API version in plugin manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,15 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -64,15 +64,6 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-  </build>
-
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
@@ -85,4 +76,13 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <build>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+  </build>
 </project>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    This plugin provides the <a href="https://github.com/flyway/flyway">Flyway</a> APIs for other plugins.
+    This plugin provides the <a href="https://github.com/flyway/flyway">Flyway</a> APIs (v${revision}) for other plugins.
 </div>


### PR DESCRIPTION
With a little trick using maven's resource filtering strategy and parsing `$revision`, the bundled version can be displayed in the plugin manager.
I consider this useful, especially for people who aren't familiar with our CD format:

![Screenshot 2023-11-24 at 17 56 09](https://github.com/jenkinsci/flyway-api-plugin/assets/13383509/57bdf91a-0f70-46eb-b60e-c20efe8c8b42)