### PR TITLE
Remove command-line from bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,18 +50,6 @@
       </dependency>
       <dependency>
         <groupId>org.flywaydb</groupId>
-        <artifactId>flyway-commandline</artifactId>
-        <version>${revision}</version>
-        <type>tar.gz</type>
-      </dependency>
-      <dependency>
-        <groupId>org.flywaydb</groupId>
-        <artifactId>flyway-commandline</artifactId>
-        <version>${revision}</version>
-        <type>zip</type>
-      </dependency>
-      <dependency>
-        <groupId>org.flywaydb</groupId>
         <artifactId>flyway-database-postgresql</artifactId>
         <version>${revision}</version>
       </dependency>


### PR DESCRIPTION
Due to https://github.com/flyway/flyway/issues/4105

### Testing done

Consuming plugin can still define the version.

In any case command line is not packaged on the jar

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

